### PR TITLE
Update pre-packaged-results and bump version #

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdikbquery",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "FDI Knowledge base query tool.",
   "main": "build/fdikbquery.js",
   "files": [
@@ -49,7 +49,7 @@
   "dependencies": {
     "@abi-software/biolucidaclient": "^0.2.1",
     "@abi-software/mapcore-augmented-results": "^0.1.5",
-    "@abi-software/mapcore-pre-packaged-results": "^0.1.7",
+    "@abi-software/mapcore-pre-packaged-results": "^0.1.8",
     "axios": "^0.19.0",
     "broadcast-channel": "^2.2.0",
     "tippy.js": "^4.3.5",


### PR DESCRIPTION
This is to bring the directory navigation created for Stellate into the data.sparc.science